### PR TITLE
Use awk to get the auth string from wsk

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ ./wsk property get --auth -i
 Set up the `AUTH` env var: 
 
 ```sh
-$ export AUTH=`./wsk property get --auth -i`
+$ export AUTH=`./wsk property get --auth -i | awk '{ print $3; }'`
 ```
 
 Then just use curl to call e.g. the `hello` action:


### PR DESCRIPTION
Currently, the AUTH env var gets set incorrectly e.g.

```bash
export AUTH=`wsk property get --auth -i`

echo $AUTH
whisk auth 789c46b1-71f6-4ed5-8c54-816aa4f8c502:CexC2CFV0rKgG3uWoPTLiCG8oAYaxlkwvNDuiPQqUniOB52vKUCdRdGVA7tMRtL5
```

With this change, the env var gets set with just the auth string e.g.

```bash
export AUTH=`wsk property get --auth -i | awk '{ print $3; }'`

echo $AUTH
789c46b1-71f6-4ed5-8c54-816aa4f8c502:CexC2CFV0rKgG3uWoPTLiCG8oAYaxlkwvNDuiPQqUniOB52vKUCdRdGVA7tMRtL5
```